### PR TITLE
Rename article items to `section`

### DIFF
--- a/src/routes/article/[id]/+page.svelte
+++ b/src/routes/article/[id]/+page.svelte
@@ -1,10 +1,10 @@
 <script lang="ts">
-	export let data: any;
+	export let data;
 </script>
 
-{#each data.article as component (component.id)}
+{#each data.article as section (section.id)}
     <div>
-        <svelte:component this={data?.components[component.type]} data={component} />
+        <svelte:component this={data.components[section.type]} data={section} />
     </div>
 {/each}
 


### PR DESCRIPTION
I found it a bit confusing that the item of the article array was named `component`, because `data.component` also exists. IMO `section` is a better name for it.
While I was at it I removed
- the optional chaining. `data` always is an object.
- the `any` type. The svelte extension should automatically type it correctly to the return type of the `load` function, doesn't it?